### PR TITLE
Add responsive tablet and mobile views

### DIFF
--- a/src/screens/Wireframe/components/ContactSection.tsx
+++ b/src/screens/Wireframe/components/ContactSection.tsx
@@ -43,7 +43,7 @@ export const ContactSection = ({ methods }: ContactSectionProps): JSX.Element =>
             <div className="relative w-full h-full flex flex-col items-center px-8 max-w-[1000px] mx-auto">
 
                 {/* Content section split 50/50 */}
-                <div className="flex w-full gap-[51px] mt-[26px]">
+                <div className="flex w-full gap-[51px] mt-[26px] mobile:flex-col">
                     {/* Bloc gauche (description + cartes) */}
                     <div className="flex flex-col flex-1 items-start">
                         <p className="w-full text-start [font-family:'Roboto',Helvetica] font-normal text-[#ffffffbf] text-[16px] tracking-[0] leading-[normal] mb-[19px]">
@@ -81,7 +81,7 @@ export const ContactSection = ({ methods }: ContactSectionProps): JSX.Element =>
                     </div>
 
                     {/* Bloc droit (image) */}
-                    <div className="flex-1 text-card-foreground h-[245px] shadow aspect-square bg-[#0f0f0f26] rounded-[15px] backdrop-blur-md overflow-hidden">
+                    <div className="flex-1 text-card-foreground h-[245px] shadow aspect-square bg-[#0f0f0f26] rounded-[15px] backdrop-blur-md overflow-hidden tablet:hidden">
                         <img className="w-full h-full object-cover" alt="About" src="/wireframe/about.png" />
                     </div>
                 </div>

--- a/src/screens/Wireframe/components/HeroSection.tsx
+++ b/src/screens/Wireframe/components/HeroSection.tsx
@@ -86,13 +86,13 @@ export const HeroSection = ({ techStack }: HeroSectionProps): JSX.Element => {
           </div>
         </div>
       </div>
-      <div className="flex w-full mt-[80px] gap-6 justify-center flex-col md:flex-row">
-      <Card className="w-full md:w-[403px] md:h-[429px] bg-[#0f0f0f26] rounded-[32px] backdrop-blur-md overflow-hidden">
+      <div className="flex w-full mt-[80px] gap-6 justify-center flex-row mobile:flex-col">
+      <Card className="w-full md:w-[403px] md:h-[429px] bg-[#0f0f0f26] rounded-[32px] backdrop-blur-md overflow-hidden tablet:w-2/5 mobile:w-full">
         <CardContent className="p-0 h-full">
           <img className="w-full h-full object-cover" alt="About" src="/wireframe/about.png" />
         </CardContent>
       </Card>
-      <div className="flex flex-col gap-6 w-full md:w-auto">
+      <div className="flex flex-col gap-6 w-full md:w-auto tablet:w-3/5 mobile:w-full">
         <Card className="w-full md:w-[524px] md:h-[305px] bg-[#a265ff0d] rounded-[32px] backdrop-blur-md">
           <CardContent className="p-6">
             <h2 className="[font-family:'Days_One',Helvetica] font-normal text-white text-[19px] text-center tracking-[0] leading-[19px] mb-6">MON PARCOURS</h2>

--- a/src/screens/Wireframe/components/NavigationHeader.tsx
+++ b/src/screens/Wireframe/components/NavigationHeader.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Button } from "../../../components/ui/button";
 import { Download } from "lucide-react";
 import { Card, CardContent } from "../../../components/ui/card";
@@ -19,48 +19,79 @@ interface NavigationHeaderProps {
   onNavItemClick?: (index: number) => void;
 }
 
-export const NavigationHeader = ({ navItems, onNavItemClick }: NavigationHeaderProps): JSX.Element => (
-  <header className="fixed top-0 left-0 w-full z-20 bg-white/4 backdrop-blur-md py-[5px]">
-    <div className="mx-auto flex w-full max-w-[1440px] items-center justify-between">
-      <img className="h-[64px] w-[90px] object-cover" alt="Logo removebg" src="/wireframe/logo.png" />
-      <Card className="w-[780px] h-[56px] bg-[#0a0612cc] backdrop-blur-sm rounded-[35px]">
-        <CardContent className="p-0 h-full w-full flex items-center justify-center">
-          <NavigationMenu className="w-full">
-            <NavigationMenuList className="w-full h-full flex items-center justify-around gap-4">
-              {navItems.map((item, index) => (
-                <NavigationMenuItem key={index} className="relative h-full">
-                  <a
-                    href={`#${item.targetId}`}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      document
-                        .getElementById(item.targetId)
-                        ?.scrollIntoView({ behavior: "smooth" });
-                      onNavItemClick?.(index);
-                    }}
-                    className="relative flex h-full items-center justify-center px-5 py-2 transition-all duration-200 hover:text-[#a265ff] hover:scale-105"
-                  >
-                    {item.isActive ? (
-                      <div className="absolute inset-0 rounded-[35px] bg-[#a265ff] transition-all duration-200" />
-                    ) : null}
-                    <span
-                      className={`relative z-10 [font-family:'Days_One',Helvetica] font-normal text-white text-sm tracking-[0] leading-[normal]`}
+export const NavigationHeader = ({ navItems, onNavItemClick }: NavigationHeaderProps): JSX.Element => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <header className="fixed top-0 left-0 w-full z-20 bg-white/4 backdrop-blur-md py-[5px]">
+      <div className="mx-auto flex w-full max-w-[1440px] items-center justify-between px-4">
+        <img className="h-[64px] w-[90px] object-cover" alt="Logo removebg" src="/wireframe/logo.png" />
+
+        <Card className="w-[780px] h-[56px] bg-[#0a0612cc] backdrop-blur-sm rounded-[35px] tabletLandscape:hidden">
+          <CardContent className="p-0 h-full w-full flex items-center justify-center">
+            <NavigationMenu className="w-full">
+              <NavigationMenuList className="w-full h-full flex items-center justify-around gap-4">
+                {navItems.map((item, index) => (
+                  <NavigationMenuItem key={index} className="relative h-full">
+                    <a
+                      href={`#${item.targetId}`}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        document.getElementById(item.targetId)?.scrollIntoView({ behavior: "smooth" });
+                        onNavItemClick?.(index);
+                      }}
+                      className="relative flex h-full items-center justify-center px-5 py-2 transition-all duration-200 hover:text-[#a265ff] hover:scale-105"
                     >
-                      {item.name}
-                    </span>
-                  </a>
-                </NavigationMenuItem>
-              ))}
-            </NavigationMenuList>
-          </NavigationMenu>
-        </CardContent>
-      </Card>
-      <Button className="w-[100px] h-[42px] mr-6 bg-[#a265ff] rounded-[35px] flex items-center justify-center gap-2 hover:bg-[#924cff] transition-colors duration-200">
-        <Download className="w-5 h-5 text-white" />
-        <span className="[font-family:'Poppins',Helvetica] font-medium text-white text-lg tracking-[0] leading-[normal]">CV</span>
-      </Button>
-    </div>
-  </header>
-);
+                      {item.isActive ? (
+                        <div className="absolute inset-0 rounded-[35px] bg-[#a265ff] transition-all duration-200" />
+                      ) : null}
+                      <span className="relative z-10 [font-family:'Days_One',Helvetica] font-normal text-white text-sm tracking-[0] leading-[normal]">
+                        {item.name}
+                      </span>
+                    </a>
+                  </NavigationMenuItem>
+                ))}
+              </NavigationMenuList>
+            </NavigationMenu>
+          </CardContent>
+        </Card>
+
+        <Button className="w-[100px] h-[42px] mr-6 bg-[#a265ff] rounded-[35px] flex items-center justify-center gap-2 hover:bg-[#924cff] transition-colors duration-200 tabletLandscape:hidden">
+          <Download className="w-5 h-5 text-white" />
+          <span className="[font-family:'Poppins',Helvetica] font-medium text-white text-lg tracking-[0] leading-[normal]">CV</span>
+        </Button>
+
+        <button
+          onClick={() => setOpen(!open)}
+          className="hidden tabletLandscape:flex flex-col items-end justify-center w-8 h-8 relative"
+        >
+          <span className="block w-full h-0.5 bg-white mb-1" />
+          <span className="block w-full h-0.5 bg-white mb-1" />
+          <span className="block w-1/2 h-0.5 bg-white self-end" />
+        </button>
+      </div>
+
+      {open && (
+        <div className="tabletLandscape:flex hidden absolute right-4 top-[70px] bg-[#0a0612cc] backdrop-blur-sm rounded-[12px] p-4 flex-col gap-3">
+          {navItems.map((item, index) => (
+            <a
+              key={index}
+              href={`#${item.targetId}`}
+              onClick={(e) => {
+                e.preventDefault();
+                document.getElementById(item.targetId)?.scrollIntoView({ behavior: "smooth" });
+                onNavItemClick?.(index);
+                setOpen(false);
+              }}
+              className="text-white [font-family:'Days_One',Helvetica] hover:text-[#a265ff]"
+            >
+              {item.name}
+            </a>
+          ))}
+        </div>
+      )}
+    </header>
+  );
+};
 
 export default NavigationHeader;

--- a/src/screens/Wireframe/components/ProcessSection.tsx
+++ b/src/screens/Wireframe/components/ProcessSection.tsx
@@ -73,7 +73,7 @@ export const ProcessSection = ({ steps }: ProcessSectionProps): JSX.Element => {
                 data-index={index}
                 className="relative z-10 flex items-center gap-6 px-6 justify-center"
               >
-                <div className="relative flex flex-col items-center">
+                <div className="relative flex flex-col items-center tablet:hidden">
                   <div
                     className={`flex items-center justify-center w-[117px] h-[72px] rounded-full [text-shadow:0_0_24px_#a265ff] [font-family:'Days_One',Helvetica] text-[72px] tracking-[0] leading-none transition-all duration-300 ${
                       index === currentStepIndex

--- a/src/screens/Wireframe/components/SocialSidebar.tsx
+++ b/src/screens/Wireframe/components/SocialSidebar.tsx
@@ -11,7 +11,7 @@ interface SocialSidebarProps {
 }
 
 export const SocialSidebar = ({ links }: SocialSidebarProps): JSX.Element => (
-  <div className="fixed top-1/2 -translate-y-1/2 left-4 flex flex-col items-center gap-4 z-10">
+  <div className="fixed top-1/2 -translate-y-1/2 left-4 flex flex-col items-center gap-4 z-10 tabletLandscape:hidden">
     {links.map((link, index) => (
       <Button
         key={index}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -71,8 +71,17 @@ module.exports = {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
       },
+      screens: {
+        tabletLandscape: { max: "1024px" },
+        tablet: { max: "900px" },
+        mobile: { max: "720px" },
+      },
     },
-    container: { center: true, padding: "2rem", screens: { "2xl": "1400px" } },
+    container: {
+      center: true,
+      padding: "2rem",
+      screens: { "2xl": "1400px" },
+    },
   },
   plugins: [],
   darkMode: ["class"],


### PR DESCRIPTION
## Summary
- configure custom breakpoints in Tailwind
- hide social sidebar below 1024px and add burger menu
- adjust hero layout with 40/60 split on tablets
- hide process numbers/progress bars on tablets
- remove contact image on tablet

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f7c468f008320bb7b0b03297e19fe